### PR TITLE
Update compiler version to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
For now, I noticed that the _Stream API_ is already used in the code. See `com.redislabs.redisai.RedisAI#setScriptFile`, Maybe we should upgrade the maven compiler version to 1.8+ and comment it in the readme. What do you think? @filipecosta90 @gkorland 