### PR TITLE
Support for AI.DAGRUN and AI.DAGRUN_RO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
 			<version>3.3.0</version>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.10</version>
+		</dependency>
 	</dependencies>
 
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -57,11 +57,6 @@
 			<version>3.3.0</version>
 			<scope>compile</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.10</version>
-		</dependency>
 	</dependencies>
 
 	<distributionManagement>

--- a/src/main/java/com/redislabs/redisai/Dag.java
+++ b/src/main/java/com/redislabs/redisai/Dag.java
@@ -28,7 +28,7 @@ public class Dag implements DagRunCommands {
 
   @Override
   public void setTensor(String key, Tensor tensor) {
-    List<byte[]> args = tensor.getTensorSetCommandBytes(key, true);
+    List<byte[]> args = tensor.tensorSetFlatArgs(key, true);
     this.commands.add(args);
     this.tensorgetflag.add(false);
   }

--- a/src/main/java/com/redislabs/redisai/Dag.java
+++ b/src/main/java/com/redislabs/redisai/Dag.java
@@ -1,0 +1,79 @@
+package com.redislabs.redisai;
+
+import java.util.ArrayList;
+import java.util.List;
+import redis.clients.jedis.util.SafeEncoder;
+
+public class Dag implements DagRunCommands {
+  List<List<byte[]>> commands;
+  List<Boolean> tensorgetflag;
+
+  /** Direct acyclic graph of operations to run within RedisAI */
+  public Dag() {
+    this.commands = new ArrayList<>();
+    this.tensorgetflag = new ArrayList<>();
+  }
+
+  protected List<?> processDagReply(List<?> reply) {
+    List<Object> outputList = new ArrayList<>(reply.size());
+    for (int i = 0; i < reply.size(); i++) {
+      if (this.tensorgetflag.get(i) == true) {
+        outputList.add(Tensor.createTensorFromRespReply((List<?>) reply.get(i)));
+      } else {
+        outputList.add(reply.get(i));
+      }
+    }
+    return outputList;
+  }
+
+  @Override
+  public void setTensor(String key, Tensor tensor) {
+    List<byte[]> args = tensor.getTensorSetCommandBytes(key, true);
+    this.commands.add(args);
+    this.tensorgetflag.add(false);
+  }
+
+  @Override
+  public void getTensor(String key) {
+    List<byte[]> args = Tensor.tensorGetFlatArgs(key, true);
+    this.commands.add(args);
+    this.tensorgetflag.add(true);
+  }
+
+  @Override
+  public void runModel(String key, String[] inputs, String[] outputs) {
+    List<byte[]> args = Model.modelRunFlatArgs(key, inputs, outputs, true);
+    this.commands.add(args);
+    this.tensorgetflag.add(false);
+  }
+
+  @Override
+  public void runScript(String key, String function, String[] inputs, String[] outputs) {
+    List<byte[]> args = Script.scriptRunFlatArgs(key, function, inputs, outputs, true);
+    this.commands.add(args);
+    this.tensorgetflag.add(false);
+  }
+
+  List<byte[]> dagRunFlatArgs(String[] loadKeys, String[] persistKeys) {
+    List<byte[]> args = new ArrayList<>();
+    if (loadKeys != null && loadKeys.length > 0) {
+      args.add(Keyword.LOAD.getRaw());
+      args.add(SafeEncoder.encode(String.valueOf(loadKeys.length)));
+      for (String key : loadKeys) {
+        args.add(SafeEncoder.encode(key));
+      }
+    }
+    if (persistKeys != null && persistKeys.length > 0) {
+      args.add(Keyword.PERSIST.getRaw());
+      args.add(SafeEncoder.encode(String.valueOf(persistKeys.length)));
+      for (String key : persistKeys) {
+        args.add(SafeEncoder.encode(key));
+      }
+    }
+    for (List<byte[]> command : this.commands) {
+      args.add(SafeEncoder.encode("|>"));
+      args.addAll(command);
+    }
+    return args;
+  }
+}

--- a/src/main/java/com/redislabs/redisai/Dag.java
+++ b/src/main/java/com/redislabs/redisai/Dag.java
@@ -2,7 +2,6 @@ package com.redislabs.redisai;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.lang3.ArrayUtils;
 import redis.clients.jedis.util.SafeEncoder;
 
 public class Dag implements DagRunCommands<Dag> {
@@ -58,14 +57,14 @@ public class Dag implements DagRunCommands<Dag> {
 
   List<byte[]> dagRunFlatArgs(String[] loadKeys, String[] persistKeys) {
     List<byte[]> args = new ArrayList<>();
-    if (ArrayUtils.isNotEmpty(loadKeys)) {
+    if (loadKeys != null && loadKeys.length > 0) {
       args.add(Keyword.LOAD.getRaw());
       args.add(SafeEncoder.encode(String.valueOf(loadKeys.length)));
       for (String key : loadKeys) {
         args.add(SafeEncoder.encode(key));
       }
     }
-    if (ArrayUtils.isNotEmpty(persistKeys)) {
+    if (persistKeys != null && persistKeys.length > 0) {
       args.add(Keyword.PERSIST.getRaw());
       args.add(SafeEncoder.encode(String.valueOf(persistKeys.length)));
       for (String key : persistKeys) {

--- a/src/main/java/com/redislabs/redisai/Dag.java
+++ b/src/main/java/com/redislabs/redisai/Dag.java
@@ -2,17 +2,15 @@ package com.redislabs.redisai;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang3.ArrayUtils;
 import redis.clients.jedis.util.SafeEncoder;
 
 public class Dag implements DagRunCommands {
-  List<List<byte[]>> commands;
-  List<Boolean> tensorgetflag;
+  private final List<List<byte[]>> commands = new ArrayList<>();
+  private final List<Boolean> tensorgetflag = new ArrayList<>();
 
   /** Direct acyclic graph of operations to run within RedisAI */
-  public Dag() {
-    this.commands = new ArrayList<>();
-    this.tensorgetflag = new ArrayList<>();
-  }
+  public Dag() {}
 
   protected List<?> processDagReply(List<?> reply) {
     List<Object> outputList = new ArrayList<>(reply.size());
@@ -56,14 +54,14 @@ public class Dag implements DagRunCommands {
 
   List<byte[]> dagRunFlatArgs(String[] loadKeys, String[] persistKeys) {
     List<byte[]> args = new ArrayList<>();
-    if (loadKeys != null && loadKeys.length > 0) {
+    if (ArrayUtils.isNotEmpty(loadKeys)) {
       args.add(Keyword.LOAD.getRaw());
       args.add(SafeEncoder.encode(String.valueOf(loadKeys.length)));
       for (String key : loadKeys) {
         args.add(SafeEncoder.encode(key));
       }
     }
-    if (persistKeys != null && persistKeys.length > 0) {
+    if (ArrayUtils.isNotEmpty(persistKeys)) {
       args.add(Keyword.PERSIST.getRaw());
       args.add(SafeEncoder.encode(String.valueOf(persistKeys.length)));
       for (String key : persistKeys) {
@@ -71,7 +69,7 @@ public class Dag implements DagRunCommands {
       }
     }
     for (List<byte[]> command : this.commands) {
-      args.add(SafeEncoder.encode("|>"));
+      args.add(Keyword.PIPE.getRaw());
       args.addAll(command);
     }
     return args;

--- a/src/main/java/com/redislabs/redisai/DagRunCommands.java
+++ b/src/main/java/com/redislabs/redisai/DagRunCommands.java
@@ -1,0 +1,11 @@
+package com.redislabs.redisai;
+
+public interface DagRunCommands {
+  public void setTensor(String key, Tensor tensor);
+
+  public void getTensor(String key);
+
+  public void runModel(String key, String[] inputs, String[] outputs);
+
+  public void runScript(String key, String function, String[] inputs, String[] outputs);
+}

--- a/src/main/java/com/redislabs/redisai/DagRunCommands.java
+++ b/src/main/java/com/redislabs/redisai/DagRunCommands.java
@@ -1,11 +1,11 @@
 package com.redislabs.redisai;
 
-interface DagRunCommands {
-  void setTensor(String key, Tensor tensor);
+interface DagRunCommands<T> {
+  T setTensor(String key, Tensor tensor);
 
-  void getTensor(String key);
+  T getTensor(String key);
 
-  void runModel(String key, String[] inputs, String[] outputs);
+  T runModel(String key, String[] inputs, String[] outputs);
 
-  void runScript(String key, String function, String[] inputs, String[] outputs);
+  T runScript(String key, String function, String[] inputs, String[] outputs);
 }

--- a/src/main/java/com/redislabs/redisai/DagRunCommands.java
+++ b/src/main/java/com/redislabs/redisai/DagRunCommands.java
@@ -1,11 +1,11 @@
 package com.redislabs.redisai;
 
-public interface DagRunCommands {
-  public void setTensor(String key, Tensor tensor);
+interface DagRunCommands {
+  void setTensor(String key, Tensor tensor);
 
-  public void getTensor(String key);
+  void getTensor(String key);
 
-  public void runModel(String key, String[] inputs, String[] outputs);
+  void runModel(String key, String[] inputs, String[] outputs);
 
-  public void runScript(String key, String function, String[] inputs, String[] outputs);
+  void runScript(String key, String function, String[] inputs, String[] outputs);
 }

--- a/src/main/java/com/redislabs/redisai/Keyword.java
+++ b/src/main/java/com/redislabs/redisai/Keyword.java
@@ -4,26 +4,30 @@ import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.util.SafeEncoder;
 
 public enum Keyword implements ProtocolCommand {
-  INPUTS("INPUTS"),
-  OUTPUTS("OUTPUTS"),
-  META("META"),
-  VALUES("VALUES"),
-  BLOB("BLOB"),
-  SOURCE("SOURCE"),
-  RESETSTAT("RESETSTAT"),
-  TAG("TAG"),
-  BATCHSIZE("BATCHSIZE"),
-  MINBATCHSIZE("MINBATCHSIZE"),
-  BACKENDSPATH("BACKENDSPATH"),
-  LOADBACKEND("LOADBACKEND"),
-  LOAD("LOAD"),
-  PERSIST("PERSIST"),
+  INPUTS,
+  OUTPUTS,
+  META,
+  VALUES,
+  BLOB,
+  SOURCE,
+  RESETSTAT,
+  TAG,
+  BATCHSIZE,
+  MINBATCHSIZE,
+  BACKENDSPATH,
+  LOADBACKEND,
+  LOAD,
+  PERSIST,
   PIPE("|>");
 
   private final byte[] raw;
 
-  Keyword(String s) {
-    raw = SafeEncoder.encode(s);
+  Keyword() {
+    raw = SafeEncoder.encode(this.name());
+  }
+
+  Keyword(String encodeStr) {
+    raw = SafeEncoder.encode(encodeStr);
   }
 
   public byte[] getRaw() {

--- a/src/main/java/com/redislabs/redisai/Keyword.java
+++ b/src/main/java/com/redislabs/redisai/Keyword.java
@@ -16,7 +16,9 @@ public enum Keyword implements ProtocolCommand {
   BATCHSIZE,
   MINBATCHSIZE,
   BACKENDSPATH,
-  LOADBACKEND;
+  LOADBACKEND,
+  LOAD,
+  PERSIST;
 
   private final byte[] raw;
 

--- a/src/main/java/com/redislabs/redisai/Keyword.java
+++ b/src/main/java/com/redislabs/redisai/Keyword.java
@@ -4,30 +4,26 @@ import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.util.SafeEncoder;
 
 public enum Keyword implements ProtocolCommand {
-  INPUTS,
-  OUTPUTS,
-  META,
-  VALUES,
-  BLOB,
-  SOURCE,
-  RESETSTAT,
-  TAG,
-  BATCHSIZE,
-  MINBATCHSIZE,
-  BACKENDSPATH,
-  LOADBACKEND,
-  LOAD,
-  PERSIST,
-  PIPE;
+  INPUTS("INPUTS"),
+  OUTPUTS("OUTPUTS"),
+  META("META"),
+  VALUES("VALUES"),
+  BLOB("BLOB"),
+  SOURCE("SOURCE"),
+  RESETSTAT("RESETSTAT"),
+  TAG("TAG"),
+  BATCHSIZE("BATCHSIZE"),
+  MINBATCHSIZE("MINBATCHSIZE"),
+  BACKENDSPATH("BACKENDSPATH"),
+  LOADBACKEND("LOADBACKEND"),
+  LOAD("LOAD"),
+  PERSIST("PERSIST"),
+  PIPE("|>");
 
   private final byte[] raw;
 
-  Keyword() {
-    if (this.name() == "PIPE") {
-      raw = SafeEncoder.encode("|>");
-    } else {
-      raw = SafeEncoder.encode(this.name());
-    }
+  Keyword(String s) {
+    raw = SafeEncoder.encode(s);
   }
 
   public byte[] getRaw() {

--- a/src/main/java/com/redislabs/redisai/Keyword.java
+++ b/src/main/java/com/redislabs/redisai/Keyword.java
@@ -4,7 +4,6 @@ import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.util.SafeEncoder;
 
 public enum Keyword implements ProtocolCommand {
-  TENSOR,
   INPUTS,
   OUTPUTS,
   META,
@@ -18,12 +17,17 @@ public enum Keyword implements ProtocolCommand {
   BACKENDSPATH,
   LOADBACKEND,
   LOAD,
-  PERSIST;
+  PERSIST,
+  PIPE;
 
   private final byte[] raw;
 
   Keyword() {
-    raw = SafeEncoder.encode(this.name());
+    if (this.name() == "PIPE") {
+      raw = SafeEncoder.encode("|>");
+    } else {
+      raw = SafeEncoder.encode(this.name());
+    }
   }
 
   public byte[] getRaw() {

--- a/src/main/java/com/redislabs/redisai/Model.java
+++ b/src/main/java/com/redislabs/redisai/Model.java
@@ -233,4 +233,24 @@ public class Model {
     args.add(blob);
     return args;
   }
+
+  protected static List<byte[]> modelRunFlatArgs(
+      String key, String[] inputs, String[] outputs, boolean includeCommandName) {
+    List<byte[]> args = new ArrayList<>();
+    if (includeCommandName) {
+      args.add(Command.MODEL_RUN.getRaw());
+    }
+    args.add(SafeEncoder.encode(key));
+
+    args.add(Keyword.INPUTS.getRaw());
+    for (String input : inputs) {
+      args.add(SafeEncoder.encode(input));
+    }
+
+    args.add(Keyword.OUTPUTS.getRaw());
+    for (String output : outputs) {
+      args.add(SafeEncoder.encode(output));
+    }
+    return args;
+  }
 }

--- a/src/main/java/com/redislabs/redisai/RedisAI.java
+++ b/src/main/java/com/redislabs/redisai/RedisAI.java
@@ -112,7 +112,7 @@ public class RedisAI {
    */
   public boolean setTensor(String key, Tensor tensor) {
     try (Jedis conn = getConnection()) {
-      List<byte[]> args = tensor.getTensorSetCommandBytes(key, false);
+      List<byte[]> args = tensor.tensorSetFlatArgs(key, false);
       return sendCommand(conn, Command.TENSOR_SET, args.toArray(new byte[args.size()][]))
           .getStatusCodeReply()
           .equals("OK");

--- a/src/main/java/com/redislabs/redisai/RedisAI.java
+++ b/src/main/java/com/redislabs/redisai/RedisAI.java
@@ -4,7 +4,6 @@ import com.redislabs.redisai.exceptions.JRedisAIRunTimeException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -113,7 +112,7 @@ public class RedisAI {
    */
   public boolean setTensor(String key, Tensor tensor) {
     try (Jedis conn = getConnection()) {
-      List<byte[]> args = tensor.getTensorSetCommandBytes(key);
+      List<byte[]> args = tensor.getTensorSetCommandBytes(key, false);
       return sendCommand(conn, Command.TENSOR_SET, args.toArray(new byte[args.size()][]))
           .getStatusCodeReply()
           .equals("OK");
@@ -131,13 +130,9 @@ public class RedisAI {
    */
   public Tensor getTensor(String key) throws JRedisAIRunTimeException {
     try (Jedis conn = getConnection()) {
+      List<byte[]> args = Tensor.tensorGetFlatArgs(key, false);
       List<?> reply =
-          sendCommand(
-                  conn,
-                  Command.TENSOR_GET,
-                  SafeEncoder.encode(key),
-                  Keyword.META.getRaw(),
-                  Keyword.VALUES.getRaw())
+          sendCommand(conn, Command.TENSOR_GET, args.toArray(new byte[args.size()][]))
               .getObjectMultiBulkReply();
       if (reply.isEmpty()) {
         return null;
@@ -328,20 +323,7 @@ public class RedisAI {
   public boolean runModel(String key, String[] inputs, String[] outputs) {
 
     try (Jedis conn = getConnection()) {
-
-      List<byte[]> args = new ArrayList<>();
-      args.add(SafeEncoder.encode(key));
-
-      args.add(Keyword.INPUTS.getRaw());
-      for (String input : inputs) {
-        args.add(SafeEncoder.encode(input));
-      }
-
-      args.add(Keyword.OUTPUTS.getRaw());
-      for (String output : outputs) {
-        args.add(SafeEncoder.encode(output));
-      }
-
+      List<byte[]> args = Model.modelRunFlatArgs(key, inputs, outputs, false);
       return sendCommand(conn, Command.MODEL_RUN, args.toArray(new byte[args.size()][]))
           .getStatusCodeReply()
           .equals("OK");
@@ -355,27 +337,56 @@ public class RedisAI {
   public boolean runScript(String key, String function, String[] inputs, String[] outputs) {
 
     try (Jedis conn = getConnection()) {
-
-      List<byte[]> args = new ArrayList<>();
-      args.add(SafeEncoder.encode(key));
-      args.add(SafeEncoder.encode(function));
-
-      args.add(Keyword.INPUTS.getRaw());
-      for (String input : inputs) {
-        args.add(SafeEncoder.encode(input));
-      }
-
-      args.add(Keyword.OUTPUTS.getRaw());
-      for (String output : outputs) {
-        args.add(SafeEncoder.encode(output));
-      }
-
+      List<byte[]> args = Script.scriptRunFlatArgs(key, function, inputs, outputs, false);
       return sendCommand(conn, Command.SCRIPT_RUN, args.toArray(new byte[args.size()][]))
           .getStatusCodeReply()
           .equals("OK");
 
     } catch (JedisDataException ex) {
       throw new RedisAIException(ex);
+    }
+  }
+
+  /**
+   * Direct mapping to AI.DAGRUN specifies a direct acyclic graph of operations to run within
+   * RedisAI
+   *
+   * @param loadKeys
+   * @param persistKeys
+   * @param dag
+   * @return
+   */
+  public List<?> dagRun(String[] loadKeys, String[] persistKeys, Dag dag) {
+    try (Jedis conn = getConnection()) {
+      List<byte[]> args = dag.dagRunFlatArgs(loadKeys, persistKeys);
+      List<?> reply =
+          sendCommand(conn, Command.DAGRUN, args.toArray(new byte[args.size()][]))
+              .getObjectMultiBulkReply();
+      if (reply.isEmpty()) {
+        return null;
+      }
+      return dag.processDagReply(reply);
+    }
+  }
+
+  /**
+   * Direct mapping to AI.DAGRUN_RO specifies a Read Only direct acyclic graph of operations to run
+   * within RedisAI
+   *
+   * @param loadKeys
+   * @param dag
+   * @return
+   */
+  public List<?> dagRunReadOnly(String[] loadKeys, Dag dag) {
+    try (Jedis conn = getConnection()) {
+      List<byte[]> args = dag.dagRunFlatArgs(loadKeys, null);
+      List<?> reply =
+          sendCommand(conn, Command.DAGRUN_RO, args.toArray(new byte[args.size()][]))
+              .getObjectMultiBulkReply();
+      if (reply.isEmpty()) {
+        return null;
+      }
+      return dag.processDagReply(reply);
     }
   }
 

--- a/src/main/java/com/redislabs/redisai/Script.java
+++ b/src/main/java/com/redislabs/redisai/Script.java
@@ -147,4 +147,24 @@ public class Script {
                 .collect(Collectors.joining("\n"))
             + "\n";
   }
+
+  protected static List<byte[]> scriptRunFlatArgs(
+      String key, String function, String[] inputs, String[] outputs, boolean includeCommandName) {
+    List<byte[]> args = new ArrayList<>();
+    if (includeCommandName) {
+      args.add(Command.SCRIPT_RUN.getRaw());
+    }
+    args.add(SafeEncoder.encode(key));
+    args.add(SafeEncoder.encode(function));
+    args.add(Keyword.INPUTS.getRaw());
+    for (String input : inputs) {
+      args.add(SafeEncoder.encode(input));
+    }
+
+    args.add(Keyword.OUTPUTS.getRaw());
+    for (String output : outputs) {
+      args.add(SafeEncoder.encode(output));
+    }
+    return args;
+  }
 }

--- a/src/main/java/com/redislabs/redisai/Tensor.java
+++ b/src/main/java/com/redislabs/redisai/Tensor.java
@@ -97,7 +97,7 @@ public class Tensor {
    * @param key name of key to store the Model
    * @return
    */
-  protected List<byte[]> getTensorSetCommandBytes(String key, boolean includeCommandName) {
+  protected List<byte[]> tensorSetFlatArgs(String key, boolean includeCommandName) {
     List<byte[]> args = new ArrayList<>();
     if (includeCommandName) {
       args.add(Command.TENSOR_SET.getRaw());

--- a/src/main/java/com/redislabs/redisai/Tensor.java
+++ b/src/main/java/com/redislabs/redisai/Tensor.java
@@ -97,8 +97,11 @@ public class Tensor {
    * @param key name of key to store the Model
    * @return
    */
-  protected List<byte[]> getTensorSetCommandBytes(String key) {
+  protected List<byte[]> getTensorSetCommandBytes(String key, boolean includeCommandName) {
     List<byte[]> args = new ArrayList<>();
+    if (includeCommandName) {
+      args.add(Command.TENSOR_SET.getRaw());
+    }
     args.add(SafeEncoder.encode(key));
     args.add(dataType.getRaw());
     for (long shapeDimension : shape) {
@@ -106,6 +109,17 @@ public class Tensor {
     }
     args.add(Keyword.VALUES.getRaw());
     args.addAll(dataType.toByteArray(values, shape));
+    return args;
+  }
+
+  protected static List<byte[]> tensorGetFlatArgs(String key, boolean includeCommandName) {
+    List<byte[]> args = new ArrayList<>();
+    if (includeCommandName) {
+      args.add(Command.TENSOR_GET.getRaw());
+    }
+    args.add(SafeEncoder.encode(key));
+    args.add(Keyword.META.getRaw());
+    args.add(Keyword.VALUES.getRaw());
     return args;
   }
 }

--- a/src/test/java/com/redislabs/redisai/DagTest.java
+++ b/src/test/java/com/redislabs/redisai/DagTest.java
@@ -1,6 +1,7 @@
 package com.redislabs.redisai;
 
 import java.util.List;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,13 +18,13 @@ public class DagTest {
       conn.flushAll();
     }
   }
-  //
-  //    @After
-  //    public void tearDown(){
-  //        try (Jedis conn = pool.getResource()) {
-  //            conn.flushAll();
-  //        }
-  //    }
+
+  @After
+  public void tearDown() {
+    try (Jedis conn = pool.getResource()) {
+      conn.flushAll();
+    }
+  }
 
   /** ai.dagrun simple modelrun tensorget positive testing with load clause */
   @Test

--- a/src/test/java/com/redislabs/redisai/DagTest.java
+++ b/src/test/java/com/redislabs/redisai/DagTest.java
@@ -1,0 +1,161 @@
+package com.redislabs.redisai;
+
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+public class DagTest {
+  private final JedisPool pool = new JedisPool();
+  private final RedisAI client = new RedisAI(pool);
+
+  @Before
+  public void setUp() {
+    try (Jedis conn = pool.getResource()) {
+      conn.flushAll();
+    }
+  }
+  //
+  //    @After
+  //    public void tearDown(){
+  //        try (Jedis conn = pool.getResource()) {
+  //            conn.flushAll();
+  //        }
+  //    }
+
+  /** ai.dagrun simple modelrun tensorget positive testing with load clause */
+  @Test
+  public void dagrunWithLoadPersist() {
+    ClassLoader classLoader = getClass().getClassLoader();
+    String model = classLoader.getResource("test_data/graph.pb").getFile();
+    String[] inputs = new String[] {"a", "b"};
+    String[] outputs = new String[] {"mul"};
+    Assert.assertTrue(client.setModel("mul", Backend.TF, Device.CPU, inputs, outputs, model));
+    Dag dag = new Dag();
+
+    String keyA = "tensorA";
+    String keyB = "tensorB";
+    Tensor t1 = new Tensor(DataType.FLOAT, new long[] {1, 2}, new float[][] {{1, 2}});
+    Assert.assertTrue(client.setTensor(keyA, t1));
+    Assert.assertTrue(client.setTensor(keyB, t1));
+
+    dag.runModel("mul", new String[] {"tensorA", "tensorB"}, new String[] {"tensorC"});
+    dag.getTensor("tensorC");
+    List<?> result =
+        client.dagRun(new String[] {"tensorA", "tensorB"}, new String[] {"tensorC"}, dag);
+    float[] expected = new float[] {1, 4};
+
+    Tensor tensorC = (Tensor) result.get(1);
+    float[] values = (float[]) tensorC.getValues();
+    Assert.assertEquals("Assert same shape of values", 2, values.length);
+    Assert.assertArrayEquals(expected, values, (float) 0.1);
+
+    Tensor tensorCC = client.getTensor("tensorC");
+    values = (float[]) tensorCC.getValues();
+    Assert.assertEquals("Assert same shape of values", 2, values.length);
+    Assert.assertArrayEquals(expected, values, (float) 0.1);
+  }
+
+  /**
+   * ai.dagrun simple tensorset modelrun tensorget positive testing without load or persist clauses
+   */
+  @Test
+  public void dagrunWithoutLoadOrPersist() {
+    ClassLoader classLoader = getClass().getClassLoader();
+    String model = classLoader.getResource("test_data/graph.pb").getFile();
+    String[] inputs = new String[] {"a", "b"};
+    String[] outputs = new String[] {"mul"};
+    Assert.assertTrue(client.setModel("mul", Backend.TF, Device.CPU, inputs, outputs, model));
+    Dag dag = new Dag();
+
+    String keyA = "tensorA";
+    String keyB = "tensorB";
+    String keyC = "tensorC";
+    Tensor tA = new Tensor(DataType.FLOAT, new long[] {1, 2}, new float[][] {{1, 2}});
+    Tensor tB = new Tensor(DataType.FLOAT, new long[] {1, 2}, new float[][] {{2, 3}});
+    dag.setTensor(keyA, tA);
+    dag.setTensor(keyB, tB);
+    dag.runModel("mul", new String[] {keyA, keyB}, new String[] {keyC});
+    dag.getTensor(keyC);
+    List<?> result = client.dagRun(null, null, dag);
+    float[] expected = new float[] {2, 6};
+
+    Tensor tensorC = (Tensor) result.get(3);
+    float[] values = (float[]) tensorC.getValues();
+    Assert.assertEquals("Assert same shape of values", 2, values.length);
+    Assert.assertArrayEquals(expected, values, (float) 0.1);
+  }
+
+  /**
+   * ai.dagrun simple tensorset modelrun tensorget positive testing without load or persist clauses
+   */
+  @Test
+  public void dagRunReadOnlyWithoutLoad() {
+    ClassLoader classLoader = getClass().getClassLoader();
+    String model = classLoader.getResource("test_data/graph.pb").getFile();
+    String[] inputs = new String[] {"a", "b"};
+    String[] outputs = new String[] {"mul"};
+    Assert.assertTrue(client.setModel("mul", Backend.TF, Device.CPU, inputs, outputs, model));
+    Dag dag = new Dag();
+
+    String keyA = "tensorA";
+    String keyB = "tensorB";
+    String keyC = "tensorC";
+    Tensor tA = new Tensor(DataType.FLOAT, new long[] {1, 2}, new float[][] {{1, 2}});
+    Tensor tB = new Tensor(DataType.FLOAT, new long[] {1, 2}, new float[][] {{2, 3}});
+    dag.setTensor(keyA, tA);
+    dag.setTensor(keyB, tB);
+    dag.runModel("mul", new String[] {keyA, keyB}, new String[] {keyC});
+    dag.getTensor(keyC);
+    List<?> result = client.dagRunReadOnly(null, dag);
+    float[] expected = new float[] {2, 6};
+    Tensor tensorC = (Tensor) result.get(3);
+    float[] values = (float[]) tensorC.getValues();
+    Assert.assertEquals("Assert same shape of values", 2, values.length);
+    Assert.assertArrayEquals(expected, values, (float) 0.1);
+  }
+
+  /** ai.dagrun test with tensorset modelrun tensorget scriptrun tensorget */
+  @Test
+  public void dagRunWithAllCommands() {
+    ClassLoader classLoader = getClass().getClassLoader();
+    String model = classLoader.getResource("test_data/graph.pb").getFile();
+    String[] inputs = new String[] {"a", "b"};
+    String[] outputs = new String[] {"mul"};
+    Assert.assertTrue(client.setModel("mul", Backend.TF, Device.CPU, inputs, outputs, model));
+
+    String scriptFile = classLoader.getResource("test_data/script.txt").getFile();
+    Assert.assertTrue(client.setScriptFile("script", Device.CPU, scriptFile));
+    Dag dag = new Dag();
+
+    String keyA = "tensorA";
+    String keyB = "tensorB";
+    String keyC = "tensorC";
+    String keyD = "tensorD";
+    String keyE = "tensorE";
+    Tensor tA = new Tensor(DataType.FLOAT, new long[] {1, 2}, new float[][] {{1, 2}});
+    Tensor tB = new Tensor(DataType.FLOAT, new long[] {1, 2}, new float[][] {{2, 3}});
+    Tensor tD = new Tensor(DataType.FLOAT, new long[] {1, 2}, new float[][] {{5, 5}});
+    dag.setTensor(keyA, tA);
+    dag.setTensor(keyB, tB);
+    dag.setTensor(keyD, tD);
+    dag.runModel("mul", new String[] {keyA, keyB}, new String[] {keyC});
+    dag.getTensor(keyC);
+    dag.runScript("script", "bar", new String[] {keyC, keyD}, new String[] {keyE});
+    dag.getTensor(keyE);
+    List<?> result = client.dagRun(null, null, dag);
+    float[] expected = new float[] {2, 6};
+    Tensor tensorC = (Tensor) result.get(4);
+    float[] values = (float[]) tensorC.getValues();
+    Assert.assertEquals("Assert same shape of values", 2, values.length);
+    Assert.assertArrayEquals(expected, values, (float) 0.1);
+
+    float[] expectedSum = new float[] {7, 11};
+    Tensor tensorE = (Tensor) result.get(6);
+    float[] valuesSum = (float[]) tensorE.getValues();
+    Assert.assertEquals("Assert same shape of values", 2, valuesSum.length);
+    Assert.assertArrayEquals(expectedSum, valuesSum, (float) 0.1);
+  }
+}

--- a/src/test/java/com/redislabs/redisai/RedisAITest.java
+++ b/src/test/java/com/redislabs/redisai/RedisAITest.java
@@ -253,7 +253,6 @@ public class RedisAITest {
   public void testSetScript() {
     String script = "def bar(a, b):\n" + "    return a + b\n";
     Assert.assertTrue(client.setScript("script", Device.CPU, script));
-    //    client.getScript("script");
   }
 
   @Test


### PR DESCRIPTION
This PR adds support for DAGRUN and DAGRUN_RO commands ( including the newly added SCRIPTRUN within the DAG ).
- fixes #7 
- fixes #8 
- adds `scriptRunFlatArgs`, `modelRunFlatArgs`, `tensorGetFlatArgs` to reuse code across Dag and RedisAI files
- rename `getTensorSetCommandBytes` to `tensorSetFlatArgs` to have the same signature specs as other command arg builders